### PR TITLE
QoL updates

### DIFF
--- a/TIMBER/Analyzer.py
+++ b/TIMBER/Analyzer.py
@@ -5,7 +5,7 @@ Home of main classes for TIMBER.
 """
 
 from TIMBER.CollectionOrganizer import CollectionOrganizer
-from TIMBER.Tools.Common import GenerateHash, GetHistBinningTuple, CompileCpp, ConcatCols, GetStandardFlags, ExecuteCmd, LoadColumnNames
+from TIMBER.Tools.Common import GenerateHash, GetHistBinningTuple, CompileCpp, ConcatCols, GetStandardFlags, ExecuteCmd, LoadColumnNames, ProgressBar
 from clang import cindex
 from collections import OrderedDict
 
@@ -109,10 +109,9 @@ class analyzer(object):
         # Setup TChains for multiple or single file
         self._eventsChain = ROOT.TChain(self._eventsTreeName) 
         self.RunChain = ROOT.TChain(runTreeName) 
-        print ('Opening files...')
         if isinstance(self.fileName,list):
-            for f in self.fileName:
-                self._addFile(f)
+	    for f in ProgressBar(self.fileName, "Opening files: "):
+	        self._addFile(f)
         else:
             self._addFile(self.fileName)
         

--- a/TIMBER/Framework/TopPhi_modules/BranchCorrection.cc
+++ b/TIMBER/Framework/TopPhi_modules/BranchCorrection.cc
@@ -1,0 +1,39 @@
+#include <ROOT/RVec.hxx>
+/**
+ * @class BranchCorrection
+ * @brief Trivial class to load a branch as correction in TIMBER.
+   Taken from https://github.com/mroguljic/TIMBER/blob/Zbb_branch_py3/TIMBER/Framework/Zbb_modules/BranchCorrection.cc
+ */
+using namespace ROOT::VecOps;
+class BranchCorrection {
+
+    public:
+        BranchCorrection(){};
+        ~BranchCorrection(){};
+        RVec<float> evalCorrection(float val);
+        RVec<float> evalWeight(float val,float valUp,float valDown);
+        RVec<float> evalUncert(float valUp,float valDown);
+            
+};
+
+
+RVec<float> BranchCorrection::evalCorrection(float val){
+    RVec<float> correction(1);
+    correction[0]=val;
+    return correction;
+};
+
+RVec<float> BranchCorrection::evalWeight(float val,float valUp,float valDown){
+    RVec<float> weight(3);
+    weight[0]=val;
+    weight[1]=valUp;
+    weight[2]=valDown;
+    return weight;
+};
+
+RVec<float> BranchCorrection::evalUncert(float valUp,float valDown){
+    RVec<float> uncert(2);
+    uncert[0]=valUp;
+    uncert[1]=valDown;
+    return uncert;
+};

--- a/TIMBER/Tools/Common.py
+++ b/TIMBER/Tools/Common.py
@@ -646,4 +646,28 @@ def GenerateHash(length=8):
     '''
     return ''.join(random.choice(string.ascii_uppercase + string.ascii_lowercase + string.digits) for i in range(length))
 
+def ProgressBar(it, prefix="", size=60, out=sys.stdout):
+    '''Generate a progress bar from any iterable of a given size. Taken from: https://stackoverflow.com/a/34482761
+    Usage:
+
+    for i in ProgressBar(it):
+        # do something
+
+    @param it (iterable): Any iterable (dict, list, etc) with which to generate the amount of elements in the bar
+    @param prefix (str, optional): Prefix string to prepend to progress bar
+    @param size (int): Length of progress bar in characters
+    @param out (ostream): Output stream, i.e. file, stdout, stderr, etc
+    '''
+    count = len(it)
+    def show(j):
+        x = int(size*j/count)
+        out.write("%s[%s%s] %i/%i\r" % (prefix, u"#"*x, "."*(size-x), j, count))
+        out.flush()        
+    show(0)
+    for i, item in enumerate(it):
+        yield item
+        show(i+1)
+    out.write("\n")
+    out.flush()
+
 ## @}

--- a/TIMBER/Tools/Common.py
+++ b/TIMBER/Tools/Common.py
@@ -665,7 +665,7 @@ def ProgressBar(it, prefix="", size=60, out=sys.stdout):
         out.flush()        
     show(0)
     for i, item in enumerate(it):
-        yield item
+        yield item	# return the actual item (e.g. filename) without finishing function execution
         show(i+1)
     out.write("\n")
     out.flush()

--- a/TIMBER/Tools/Plot.py
+++ b/TIMBER/Tools/Plot.py
@@ -590,14 +590,14 @@ def EasyPlots(name, histlist, bkglist=[],signals=[],colors=[],titles=[],logy=Fal
 
                 # Do the signals
                 if len(signals) > 0: 
-                    signals[hist_index].SetLineColor(kBlue)
+                    signals[hist_index].SetLineColor(ROOT.kBlue)
                     signals[hist_index].SetLineWidth(2)
                     if logy == True:
                         signals[hist_index].SetMinimum(1e-3)
                     legends[hist_index].AddEntry(signals[hist_index],signals[hist_index].GetName().split('_')[0],'L')
                     signals[hist_index].Draw('hist same')
 
-                tot_hists[hist_index].SetFillColor(kBlack)
+                tot_hists[hist_index].SetFillColor(ROOT.kBlack)
                 tot_hists[hist_index].SetFillStyle(3354)
 
                 tot_hists[hist_index].Draw('e2 same')

--- a/TIMBER/Tools/Plot.py
+++ b/TIMBER/Tools/Plot.py
@@ -665,9 +665,9 @@ def MakePullPlot( data,bkg):
             ibkg_err = abs(bkg_down.GetBinContent(ibin)-bkg.GetBinContent(ibin))
 
         if idata_err != None: # deal with case when there's no data error (ie. bin content = 0)
-            sigma = sqrt(idata_err*idata_err + ibkg_err*ibkg_err)
+            sigma = math.sqrt(idata_err*idata_err + ibkg_err*ibkg_err)
         else:
-            sigma = sqrt(ibkg_err*ibkg_err)
+            sigma = math.sqrt(ibkg_err*ibkg_err)
 
         if sigma != 0 :
             ipull = (pull.GetBinContent(ibin))/sigma

--- a/TIMBER/Tools/Plot.py
+++ b/TIMBER/Tools/Plot.py
@@ -177,7 +177,7 @@ def CompareShapes(outfilename,year,prettyvarname,bkgs={},signals={},names={},col
             total.Draw('histsame')
         else:
             for bkg in bkgs.values():
-                bkgStack.GetXaxis().SetTitleOffset(1.1)
+                bkg.GetXaxis().SetTitleOffset(1.1)
                 _doAxisTitles(bkg,split=doSoverB)
                 bkg.Draw('same hist')
     for h in signals.values():


### PR DESCRIPTION
1. If passing in a `.txt` list of ROOT files TIMBER now performs a check to see if the `Events` TTree (specified by `eventsTreeName` in the analyzer constructor) is empty. If the new `skipEmpty` boolean is passed as True to the constructor, then the analyzer will *not* be added to the TChain used to create the RDataFrame. Otherwise, the file will be added with a warning. This is useful when adding multiple NanoAOD files, as an empty `Events` tree in just one file added will break the whole TChain. 
2. Added a progress bar to show the status of files being added to the analyzer's TChain. Previously, there was no indication of progress so TIMBER appeared to be hanging when creating an analyzer with multiple ROOT files.
3. Included a module `TIMBER/Framework/TopPhi_modules/BranchCorrection.cc` (thanks, Matej!) to allow constants to be added as columns to the RDataFrame. Useful for e.g. storing cutflow information.
4. Fixed missing namespaces in a few plotting functions.
5. Fixed incorrect reference to variable which was not yet initialized.